### PR TITLE
Update phar-file-checksums to match changes with phar-build

### DIFF
--- a/phar-file-checksums.php
+++ b/phar-file-checksums.php
@@ -100,7 +100,7 @@ if (!QUIET_MODE) {
 }
 
 try {
-	$iterator = new RecursiveDirectoryIterator($options['src']);
+    $iterator = new RecursiveDirectoryIterator($options['src']);
 
     $iterator = new RecursiveIteratorIterator($iterator, RecursiveIteratorIterator::SELF_FIRST);
 
@@ -110,63 +110,65 @@ try {
 
     // buildFromIterator unfortunately sucks and skips nested directories (?)
     foreach ($iterator as $file) {
-        if ($file->isFile()) {
-            $hash = $checksums[(string) $file] = hash_file('sha1', (string) $file); // @note can easily change the first param of hash_file into an option that can be set via a command line parameter.
-			if(VERBOSE_MODE) {
-				echo "file hash for '$file': $hash\n";
-			}
+        if (!$iterator->isDot()) {
+            if ($file->isFile()) {
+                $hash = $checksums[(string) $file] = hash_file('sha1', (string) $file); // @note can easily change the first param of hash_file into an option that can be set via a command line parameter.
+                if(VERBOSE_MODE) {
+                    echo "file hash for '$file': $hash\n";
+                }
+            }
         }
     }
 
-	try {
-		// If the checksum file doesn't exist, we'll just say a rebuild is needed.
-		if (!file_exists($options['checksum_file'])) {
-			throw new Exception("Rebuild required, checksum file not present", 12);
-		}
-		
-		$filestates = json_decode(file_get_contents($options['checksum_file']), true);
+    try {
+        // If the checksum file doesn't exist, we'll just say a rebuild is needed.
+        if (!file_exists($options['checksum_file'])) {
+            throw new Exception("Rebuild required, checksum file not present", 12);
+        }
 
-		foreach ($checksums as $file => $checksum) {
-			// On the first different thing, bail out and flag this as needing a rebuild.
-			if (!isset($filestates[$file])) {
-				throw new Exception ("Rebuild required, new file '$file' detected.", 12);
-			}
-			if ($filestates[$file] !== $checksum) {
-				if(!VERBOSE_MODE) {
-					throw new Exception("Rebuild required, file '$file' has changed.\n", 12);
-				} else { 
-					throw new Exception("Rebuild required, file '$file' has changed.\nPrevious checksum: {$filestates[$file]}\nCurrent checksum: $checksum\n", 12);
-				}
-			}
+        $filestates = json_decode(file_get_contents($options['checksum_file']), true);
 
-			unset($filestates[$file], $checksums[$file]);
-		}
-		
-		// If there were files not present in one filestate or the other, then we obviously need a rebuild.
-		if (!empty($checksums) || !empty($filestates)) {
-			throw new Exception("Rebuild required, one or more files have been deleted or added.", 12);
-		}
-	}
-	catch(Exception $e) {
-		// Dump our file of checksums now, so that we can use it later.
-		if (empty($options['nowrite_checksums'])) {
-			file_put_contents($options['checksum_file'], json_encode($checksums));
-		}
-		if (!QUIET_MODE) {
-			$parser->displayError($e->getMessage(), $e->getCode());
-		} else {
-			exit($e->getCode());
-		}
-	}
+        foreach ($checksums as $file => $checksum) {
+            // On the first different thing, bail out and flag this as needing a rebuild.
+            if (!isset($filestates[$file])) {
+                throw new Exception ("Rebuild required, new file '$file' detected.", 12);
+            }
+            if ($filestates[$file] !== $checksum) {
+                if(!VERBOSE_MODE) {
+                    throw new Exception("Rebuild required, file '$file' has changed.\n", 12);
+                } else { 
+                    throw new Exception("Rebuild required, file '$file' has changed.\nPrevious checksum: {$filestates[$file]}\nCurrent checksum: $checksum\n", 12);
+                }
+            }
 
-	if (!QUIET_MODE) {
-		echo "Rebuild not required.\n";
-		exit(0);
-	}
+            unset($filestates[$file], $checksums[$file]);
+        }
+
+        // If there were files not present in one filestate or the other, then we obviously need a rebuild.
+        if (!empty($checksums) || !empty($filestates)) {
+            throw new Exception("Rebuild required, one or more files have been deleted or added.", 12);
+        }
+    }
+    catch(Exception $e) {
+        // Dump our file of checksums now, so that we can use it later.
+        if (empty($options['nowrite_checksums'])) {
+            file_put_contents($options['checksum_file'], json_encode($checksums));
+        }
+        if (!QUIET_MODE) {
+            $parser->displayError($e->getMessage(), $e->getCode());
+        } else {
+            exit($e->getCode());
+        }
+    }
+
+    if (!QUIET_MODE) {
+        echo "Rebuild not required.\n";
+        exit(0);
+    }
 
 } catch (Exception $e) {
     echo "Error: " . $e->getMessage() . "\n";
-	exit(1);
+    exit(1);
 }
 
 class ExcludeFilesIterator extends FilterIterator {


### PR DESCRIPTION
Just some fixes.

Also fixes indentation used in phar-file-checksums to use space indentation completely (I think) to go with the rest of the codebase.

Sorry, I'm a tab indenter by habit.  :)
