### PR TITLE
Smarter require_once call

### DIFF
--- a/PharUtil/RemotePharVerifier.php
+++ b/PharUtil/RemotePharVerifier.php
@@ -1,5 +1,7 @@
 <?php
-require_once 'PharUtil/SignatureVerificationException.php';
+if(!class_exists('PharUtil_SignatureVerificationException', false) {
+    require_once 'PharUtil/SignatureVerificationException.php';
+}
 
 /**
  * Downloads remote signed Phar archives to local directory and assigns

--- a/phar-file-checksums.php
+++ b/phar-file-checksums.php
@@ -161,9 +161,9 @@ try {
         }
     }
 
+    exit(0);
     if (!QUIET_MODE) {
         echo "Rebuild not required.\n";
-        exit(0);
     }
 
 } catch (Exception $e) {

--- a/phar-file-checksums.php
+++ b/phar-file-checksums.php
@@ -161,10 +161,10 @@ try {
         }
     }
 
-    exit(0);
     if (!QUIET_MODE) {
         echo "Rebuild not required.\n";
     }
+    exit(0);
 
 } catch (Exception $e) {
     echo "Error: " . $e->getMessage() . "\n";


### PR DESCRIPTION
I'm using the `RemotePharVerifier` class in an environment where it's not being installed via PEAR, so the `require_once()` call is getting in the way; commit f31c8ce4 provides a way around this if the exception's class is already loaded somehow (I'm using a different path structure than the `require_once()` call expects, so the require is going to trip out and fail as-is).

Also included is a bonus bugfix that has been sitting in my fork for a while for phar-file-checksums.
